### PR TITLE
2025/01/feature/make aria hidden attribute configurable

### DIFF
--- a/cypress/e2e/configuration.spec.cy.js
+++ b/cypress/e2e/configuration.spec.cy.js
@@ -9,10 +9,7 @@ describe("autoEnable=false: slideshow interactivity not enabled", () => {
 
   it("Play/Pause button has no data-bhc-playing attr", () => {
     cy.visit("/", { qs: { autoEnable: false } });
-    cy.get("[data-bhc-play-pause]").should(
-      "not.have.attr",
-      "data-bhc-playing",
-    );
+    cy.get("[data-bhc-play-pause]").should("not.have.attr", "data-bhc-playing");
   });
 });
 
@@ -23,7 +20,7 @@ describe("automatic=true: slideshow plays automatically", () => {
     cy.get("[data-bhc-play-pause]").should(
       "have.attr",
       "data-bhc-playing",
-      "true",
+      "true"
     );
   });
 
@@ -51,15 +48,18 @@ describe("automatic=false: slideshow does not play automatically", () => {
     cy.get("[data-bhc-play-pause]").should(
       "have.attr",
       "data-bhc-playing",
-      "false",
+      "false"
     );
   });
 
   it("first slide's aria-hidden attr does not change to 'true'", () => {
     cy.visit("/", { qs: { automatic: false } });
     cy.wait(6000);
-    cy.get("[aria-roledescription='slide']:first-child")
-      .should("have.attr", "aria-hidden", "false");
+    cy.get("[aria-roledescription='slide']:first-child").should(
+      "have.attr",
+      "aria-hidden",
+      "false"
+    );
   });
 
   it("Previous button is not disabled", () => {
@@ -80,8 +80,34 @@ describe("interval=1000: slideshow pauses one second between slides", () => {
   it("first slide's aria-hidden is true after 1.1s", () => {
     cy.visit("/");
     cy.wait(1100);
-    cy.get("[aria-roledescription='slide']:first-child")
-      .should("have.attr", "aria-hidden", "true");
+    cy.get("[aria-roledescription='slide']:first-child").should(
+      "have.attr",
+      "aria-hidden",
+      "true"
+    );
+  });
+});
+
+// itemStateAttribute
+describe("itemStateAttribue=hidden: slides have data-hidden attribute", () => {
+  it("all slides have a hidden attribute", () => {
+    cy.visit("/", { qs: { itemStateAttribute: "data-hidden" } });
+    cy.get("[aria-roledescription='slide'][data-hidden]").should("have.length", 5);
+  });
+
+  it("third slide's data-hidden is 'false'", () => {
+    cy.visit("/", {
+      qs: {
+        automatic: false,
+        itemStateAttribute: "data-hidden",
+        startingIndex: 2,
+      },
+    });
+    cy.get("[aria-roledescription='slide']:nth-child(3)").should(
+      "have.attr",
+      "data-hidden",
+      "false"
+    );
   });
 });
 
@@ -89,7 +115,10 @@ describe("interval=1000: slideshow pauses one second between slides", () => {
 describe("startingIndex=2: slideshow starts at third slide", () => {
   it("third slide's aria-hidden is 'false'", () => {
     cy.visit("/", { qs: { automatic: false, startingIndex: 2 } });
-    cy.get("[aria-roledescription='slide']:nth-child(3)")
-      .should("have.attr", "aria-hidden", "false");
+    cy.get("[aria-roledescription='slide']:nth-child(3)").should(
+      "have.attr",
+      "aria-hidden",
+      "false"
+    );
   });
 });

--- a/cypress/fixtures/js/bh-carousel.js
+++ b/cypress/fixtures/js/bh-carousel.js
@@ -115,6 +115,7 @@
             automatic: true,
             controlType: "buttons",
             interval: 4000,
+            itemStateAttribute: "aria-hidden",
             startingIndex: 0,
         };
         firstIndex;
@@ -201,7 +202,7 @@
          */
         enable = () => {
             // Slides.
-            this.slides.forEach((slide, index) => slide.setAttribute("aria-hidden", (index !== this.current).toString()));
+            this.slides.forEach((slide, index) => slide.setAttribute(this.settings.itemStateAttribute, (index !== this.current).toString()));
             // Next button.
             this.nextButton.hidden = false;
             this.nextButton.addEventListener("click", this.handleNextClick);
@@ -244,8 +245,8 @@
             else {
                 index = destination;
             }
-            this.slides[this.current].setAttribute("aria-hidden", true.toString());
-            this.slides[index].setAttribute("aria-hidden", false.toString());
+            this.slides[this.current].setAttribute(this.settings.itemStateAttribute, true.toString());
+            this.slides[index].setAttribute(this.settings.itemStateAttribute, false.toString());
             this.current = index;
         };
         /**

--- a/cypress/fixtures/js/query2config.js
+++ b/cypress/fixtures/js/query2config.js
@@ -9,6 +9,8 @@ const configOptions = {
   // Not yet implemented.
   // controlType: (value) => ["buttons", "tabs"].includes(value),
   interval: (value) => !isNaN(value),
+  itemStateAttribute: (value) =>
+    typeof value === "string" || value instanceof String,
   startingIndex: (value) => !isNaN(value),
 };
 
@@ -31,7 +33,7 @@ const getConfigFromQuery = () => {
       switch (key) {
         case "autoEnable":
         case "automatic":
-          paramValue = (value === "true");
+          paramValue = value === "true";
           break;
 
         case "interval":
@@ -39,6 +41,7 @@ const getConfigFromQuery = () => {
           paramValue = parseInt(value);
           break;
 
+        case "itemStateAttribute":
         default:
           paramValue = value.toString();
       }

--- a/docs/classes/BhCarousel.md
+++ b/docs/classes/BhCarousel.md
@@ -138,7 +138,7 @@ BhCarousel;
 
 #### Defined in
 
-[bh-carousel.ts:192](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L192)
+[bh-carousel.ts:192](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L192)
 
 ## Methods
 
@@ -154,7 +154,7 @@ Disables carousel interactivity.
 
 #### Defined in
 
-[bh-carousel.ts:230](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L230)
+[bh-carousel.ts:230](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L230)
 
 ---
 
@@ -182,7 +182,7 @@ Enables carousel interactivity.
 
 #### Defined in
 
-[bh-carousel.ts:260](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L260)
+[bh-carousel.ts:260](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L260)
 
 ---
 
@@ -198,7 +198,7 @@ Returns a value for user's prefers-reduced-motion-setting
 
 #### Defined in
 
-[bh-carousel.ts:221](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L221)
+[bh-carousel.ts:221](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L221)
 
 ---
 
@@ -222,7 +222,7 @@ Navigates to another slide.
 
 #### Defined in
 
-[bh-carousel.ts:294](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L294)
+[bh-carousel.ts:294](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L294)
 
 ---
 
@@ -246,7 +246,7 @@ The event passed in by the listener.
 
 #### Defined in
 
-[bh-carousel.ts:326](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L326)
+[bh-carousel.ts:326](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L326)
 
 ---
 
@@ -270,7 +270,7 @@ The event passed in by the listener.
 
 #### Defined in
 
-[bh-carousel.ts:349](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L349)
+[bh-carousel.ts:349](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L349)
 
 ---
 
@@ -294,7 +294,7 @@ The event passed in by the listener.
 
 #### Defined in
 
-[bh-carousel.ts:364](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L364)
+[bh-carousel.ts:364](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L364)
 
 ---
 
@@ -318,7 +318,7 @@ The event passed in by the listener.
 
 #### Defined in
 
-[bh-carousel.ts:383](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L383)
+[bh-carousel.ts:383](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L383)
 
 ---
 
@@ -334,7 +334,7 @@ Advances carousel one slide.
 
 #### Defined in
 
-[bh-carousel.ts:396](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L396)
+[bh-carousel.ts:396](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L396)
 
 ---
 
@@ -350,7 +350,7 @@ Pauses carousel.
 
 #### Defined in
 
-[bh-carousel.ts:403](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L403)
+[bh-carousel.ts:403](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L403)
 
 ---
 
@@ -366,7 +366,7 @@ Plays carousel.
 
 #### Defined in
 
-[bh-carousel.ts:416](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L416)
+[bh-carousel.ts:416](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L416)
 
 ---
 
@@ -382,4 +382,4 @@ Reverses carousel one slide.
 
 #### Defined in
 
-[bh-carousel.ts:431](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L431)
+[bh-carousel.ts:431](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L431)

--- a/docs/classes/BhCarousel.md
+++ b/docs/classes/BhCarousel.md
@@ -138,7 +138,7 @@ BhCarousel;
 
 #### Defined in
 
-[bh-carousel.ts:186](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L186)
+[bh-carousel.ts:192](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L192)
 
 ## Methods
 
@@ -154,7 +154,7 @@ Disables carousel interactivity.
 
 #### Defined in
 
-[bh-carousel.ts:224](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L224)
+[bh-carousel.ts:230](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L230)
 
 ---
 
@@ -182,7 +182,7 @@ Enables carousel interactivity.
 
 #### Defined in
 
-[bh-carousel.ts:254](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L254)
+[bh-carousel.ts:260](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L260)
 
 ---
 
@@ -198,7 +198,7 @@ Returns a value for user's prefers-reduced-motion-setting
 
 #### Defined in
 
-[bh-carousel.ts:215](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L215)
+[bh-carousel.ts:221](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L221)
 
 ---
 
@@ -222,7 +222,7 @@ Navigates to another slide.
 
 #### Defined in
 
-[bh-carousel.ts:288](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L288)
+[bh-carousel.ts:294](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L294)
 
 ---
 
@@ -246,7 +246,7 @@ The event passed in by the listener.
 
 #### Defined in
 
-[bh-carousel.ts:320](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L320)
+[bh-carousel.ts:326](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L326)
 
 ---
 
@@ -270,7 +270,7 @@ The event passed in by the listener.
 
 #### Defined in
 
-[bh-carousel.ts:343](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L343)
+[bh-carousel.ts:349](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L349)
 
 ---
 
@@ -294,7 +294,7 @@ The event passed in by the listener.
 
 #### Defined in
 
-[bh-carousel.ts:358](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L358)
+[bh-carousel.ts:364](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L364)
 
 ---
 
@@ -318,7 +318,7 @@ The event passed in by the listener.
 
 #### Defined in
 
-[bh-carousel.ts:377](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L377)
+[bh-carousel.ts:383](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L383)
 
 ---
 
@@ -334,7 +334,7 @@ Advances carousel one slide.
 
 #### Defined in
 
-[bh-carousel.ts:390](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L390)
+[bh-carousel.ts:396](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L396)
 
 ---
 
@@ -350,7 +350,7 @@ Pauses carousel.
 
 #### Defined in
 
-[bh-carousel.ts:397](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L397)
+[bh-carousel.ts:403](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L403)
 
 ---
 
@@ -366,7 +366,7 @@ Plays carousel.
 
 #### Defined in
 
-[bh-carousel.ts:410](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L410)
+[bh-carousel.ts:416](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L416)
 
 ---
 
@@ -382,4 +382,4 @@ Reverses carousel one slide.
 
 #### Defined in
 
-[bh-carousel.ts:425](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L425)
+[bh-carousel.ts:431](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L431)

--- a/docs/coverage.svg
+++ b/docs/coverage.svg
@@ -8,10 +8,14 @@
   <rect rx="3" x="64" width="40" height="20" fill="#4fc921"/>
   <path fill="#4fc921" d="M64 0h4v20h-4z"/>
   <rect rx="3" width="104" height="20" fill="url(#a)"/>
-  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-    <text x="32" y="15" fill="#010101" fill-opacity=".3">Docs</text>
-    <text x="32" y="14">Docs</text>
-    <text x="84" y="15" fill="#010101" fill-opacity=".3">100%</text>
-    <text x="84" y="14">100%</text>
+  <g fill="#fff" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <g text-anchor="left">
+      <text x="5" y="15" fill="#010101" fill-opacity=".3">Docs</text>
+      <text x="5" y="14">Docs</text>
+    </g>
+    <g text-anchor="middle">
+      <text x="84" y="15" fill="#010101" fill-opacity=".3">95%</text>
+      <text x="84" y="14">95%</text>
+    </g>
   </g>
 </svg>

--- a/docs/interfaces/BhCarouselSettings.md
+++ b/docs/interfaces/BhCarouselSettings.md
@@ -19,7 +19,7 @@ useful when it's desireable to make the interactivity responsive.
 
 #### Defined in
 
-[bh-carousel.ts:40](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L40)
+[bh-carousel.ts:44](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L44)
 
 ---
 
@@ -33,7 +33,7 @@ allows it.
 
 #### Defined in
 
-[bh-carousel.ts:41](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L41)
+[bh-carousel.ts:45](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L45)
 
 ---
 
@@ -46,7 +46,7 @@ Currently has no effect as tab-style navigation hasn't been implemented.
 
 #### Defined in
 
-[bh-carousel.ts:42](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L42)
+[bh-carousel.ts:46](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L46)
 
 ---
 
@@ -59,7 +59,17 @@ automatically.
 
 #### Defined in
 
-[bh-carousel.ts:43](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L43)
+[bh-carousel.ts:47](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L47)
+
+---
+
+### itemStateAttribute
+
+> **itemStateAttribute**: `string`
+
+#### Defined in
+
+[bh-carousel.ts:48](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L48)
 
 ---
 
@@ -72,4 +82,4 @@ set this value to 2.
 
 #### Defined in
 
-[bh-carousel.ts:44](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L44)
+[bh-carousel.ts:49](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L49)

--- a/docs/interfaces/BhCarouselSettings.md
+++ b/docs/interfaces/BhCarouselSettings.md
@@ -19,7 +19,7 @@ useful when it's desireable to make the interactivity responsive.
 
 #### Defined in
 
-[bh-carousel.ts:44](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L44)
+[bh-carousel.ts:44](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L44)
 
 ---
 
@@ -33,7 +33,7 @@ allows it.
 
 #### Defined in
 
-[bh-carousel.ts:45](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L45)
+[bh-carousel.ts:45](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L45)
 
 ---
 
@@ -46,7 +46,7 @@ Currently has no effect as tab-style navigation hasn't been implemented.
 
 #### Defined in
 
-[bh-carousel.ts:46](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L46)
+[bh-carousel.ts:46](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L46)
 
 ---
 
@@ -59,7 +59,7 @@ automatically.
 
 #### Defined in
 
-[bh-carousel.ts:47](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L47)
+[bh-carousel.ts:47](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L47)
 
 ---
 
@@ -69,7 +69,7 @@ automatically.
 
 #### Defined in
 
-[bh-carousel.ts:48](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L48)
+[bh-carousel.ts:48](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L48)
 
 ---
 
@@ -82,4 +82,4 @@ set this value to 2.
 
 #### Defined in
 
-[bh-carousel.ts:49](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L49)
+[bh-carousel.ts:49](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L49)

--- a/docs/type-aliases/BhCarouselControls.md
+++ b/docs/type-aliases/BhCarouselControls.md
@@ -12,4 +12,4 @@ A type used to define the acceptable values BhCarouselSettings.controlType.
 
 ## Defined in
 
-[bh-carousel.ts:5](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L5)
+[bh-carousel.ts:5](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L5)

--- a/docs/type-aliases/BhCarouselControls.md
+++ b/docs/type-aliases/BhCarouselControls.md
@@ -12,4 +12,4 @@ A type used to define the acceptable values BhCarouselSettings.controlType.
 
 ## Defined in
 
-[bh-carousel.ts:5](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L5)
+[bh-carousel.ts:5](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L5)

--- a/docs/type-aliases/BhCarouselDestination.md
+++ b/docs/type-aliases/BhCarouselDestination.md
@@ -12,4 +12,4 @@ A type used to define the acceptable values BhCarouselSettings.interval.
 
 ## Defined in
 
-[bh-carousel.ts:10](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L10)
+[bh-carousel.ts:10](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L10)

--- a/docs/type-aliases/BhCarouselDestination.md
+++ b/docs/type-aliases/BhCarouselDestination.md
@@ -12,4 +12,4 @@ A type used to define the acceptable values BhCarouselSettings.interval.
 
 ## Defined in
 
-[bh-carousel.ts:10](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L10)
+[bh-carousel.ts:10](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L10)

--- a/docs/type-aliases/BhCarouselInterval.md
+++ b/docs/type-aliases/BhCarouselInterval.md
@@ -14,4 +14,4 @@ TODO For now, this is just number; we need to implement the range.
 
 ## Defined in
 
-[bh-carousel.ts:17](https://github.com/ctorgalson/bh-carousel/blob/2f7dabc4fd9fa5cf46c771341f2b4d493520ede4/src/bh-carousel.ts#L17)
+[bh-carousel.ts:17](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L17)

--- a/docs/type-aliases/BhCarouselInterval.md
+++ b/docs/type-aliases/BhCarouselInterval.md
@@ -14,4 +14,4 @@ TODO For now, this is just number; we need to implement the range.
 
 ## Defined in
 
-[bh-carousel.ts:17](https://github.com/ctorgalson/bh-carousel/blob/53037e77ed9f3875410f7f06acf29260262072f1/src/bh-carousel.ts#L17)
+[bh-carousel.ts:17](https://github.com/ctorgalson/bh-carousel/blob/f97121088c1910d9b0aa19966dee0d3b3138a34d/src/bh-carousel.ts#L17)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bh-carousel",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bh-carousel",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bh-carousel",
   "type": "module",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "An implementation of the WAI ARIA 'Carousel' pattern.",
   "homepage": "https://github.com/ctorgalson/bh-carousel",
   "license": "GPL-2.0-or-later",

--- a/src/bh-carousel.ts
+++ b/src/bh-carousel.ts
@@ -33,9 +33,9 @@ export type BhCarouselInterval = number;
  *   The interval, in milliseconds, between slides when carousel is playing
  *   automatically.
  * @property {itemStateAttribute} string
- *   The name of the attribute to set on active/inactive items. Defaults to
- *   aria-hidden; if set to any other value, than the default or `hidden`,
- *   take care for the accessibility of each item.
+ *   The name of the *boolean* attribute to set on active/inactive items.
+ *   Defaults to aria-hidden; if set to any other value, than the default or
+ *   `hidden`, take care for the accessibility of each item.
  * @property {number} startingIndex
  *   Zero-based index of starting slide. E.g. to start on the third slide,
  *   set this value to 2.

--- a/src/bh-carousel.ts
+++ b/src/bh-carousel.ts
@@ -32,6 +32,10 @@ export type BhCarouselInterval = number;
  * @property {BhCarouselInterval} interval
  *   The interval, in milliseconds, between slides when carousel is playing
  *   automatically.
+ * @property {itemStateAttribute} string
+ *   The name of the attribute to set on active/inactive items. Defaults to
+ *   aria-hidden; if set to any other value, than the default or `hidden`,
+ *   take care for the accessibility of each item.
  * @property {number} startingIndex
  *   Zero-based index of starting slide. E.g. to start on the third slide,
  *   set this value to 2.
@@ -41,6 +45,7 @@ export interface BhCarouselSettings {
   automatic: boolean;
   controlType: BhCarouselControls;
   interval: BhCarouselInterval;
+  itemStateAttribute: string;
   startingIndex: number;
 };
 
@@ -155,6 +160,7 @@ export default class BhCarousel {
     automatic: true,
     controlType: "buttons",
     interval: 4000,
+    itemStateAttribute: "aria-hidden",
     startingIndex: 0,
   };
   private firstIndex: number;
@@ -254,7 +260,7 @@ export default class BhCarousel {
   public enable = (): void => {
     // Slides.
     this.slides.forEach((slide, index) =>
-      slide.setAttribute("aria-hidden", (index !== this.current).toString()),
+      slide.setAttribute(this.settings.itemStateAttribute, (index !== this.current).toString()),
     );
     // Next button.
     this.nextButton.hidden = false;
@@ -299,11 +305,11 @@ export default class BhCarousel {
     }
 
     (this.slides[this.current] as HTMLElement).setAttribute(
-      "aria-hidden",
+      this.settings.itemStateAttribute,
       true.toString(),
     );
     (this.slides[index] as HTMLElement).setAttribute(
-      "aria-hidden",
+      this.settings.itemStateAttribute,
       false.toString(),
     );
 


### PR DESCRIPTION
Feature based on a report from @petrillek.

Using the (default) `aria-hidden` attribute makes some possible css configurations inaccessible (i.e. because it's easy and sometimes desireable to cause non-current items to be visible with css; but if they still have `aria-hidden`, it's potentially problematic).

This change leaves the default state attribute for carousel items as `aria-hidden`, but provides a new configuration option, `itemStateAttribute` that can be used to set the attribute used to any string.

It has the following limitations:

1. no checking is done to ensure it's a valid attribute name
2. the attribute will _always_ be a boolean
3. the implementation takes total responsibility for the accessibility of the carousel